### PR TITLE
Fix Warning: Illegal string offset with 'pk_i_id'

### DIFF
--- a/search-sidebar.php
+++ b/search-sidebar.php
@@ -20,7 +20,7 @@
      */
 
 $category = (array)__get('category');
-if (!isset($category['pk_i_id'])) {
+if (isset($category['pk_i_id'])) {
     $category['pk_i_id'] = null;
 }
 ?>
@@ -90,7 +90,11 @@ if (!isset($category['pk_i_id'])) {
     <fieldset>
         <div class="row ">
             <h3><?php _e('Refine category', 'bender') ; ?></h3>
-            <?php bender_sidebar_category_search($category['pk_i_id']); ?>
+            <?php 
+            if( isset($category['pk_i_id']) ) {
+                bender_sidebar_category_search($category['pk_i_id']);
+            }
+            ?>
         </div>
     </fieldset>
 </div>


### PR DESCRIPTION
Fix Warning: Illegal string offset with 'pk_i_id' in /opt/app-root/src/oc-content/themes/bender/search-sidebar.php on line 93 and 23

An illegal offset was used if Category is not selected on first page